### PR TITLE
Add planetary approach suite module

### DIFF
--- a/Modules.js
+++ b/Modules.js
@@ -39,6 +39,7 @@ module.exports = {
     hb: require('./modules/internal/hatch_breaker_limpet_controller').hb,
     hr: require('./modules/internal/hull_reinforcement_package').hr,
     ft: require('./modules/internal/internal_fuel_tank').ft,
+    pas: require('./modules/internal/planetary_approach_suite').pas,
     pv: require('./modules/internal/planetary_vehicle_hanger').pv,
     psg: require('./modules/internal/pristmatic_shield_generator').psg,
     pc: require('./modules/internal/prospector_limpet_controllers').pc,

--- a/modules/internal/planetary_approach_suite.json
+++ b/modules/internal/planetary_approach_suite.json
@@ -1,0 +1,5 @@
+{
+  "pas": [
+    { "id": "PA", "edID": 128672317, "eddbID": null, "grp": "pas", "class": 1, "rating": "I", "cost": 500, "power": 0.0, "mass": 0 }
+  ]
+}


### PR DESCRIPTION
Add the planetary approach suite module.  Not a lot of use for coriolis itself but it does have a cost and shows up in outfitting lists so it would be handy to have here.
