### PR TITLE
Add missing Elite and EDDB IDs

### DIFF
--- a/modules/hardpoints/mine_launcher.json
+++ b/modules/hardpoints/mine_launcher.json
@@ -2,6 +2,6 @@
   "nl": [
     { "id": "2j", "edID": 128049500, "eddbID": 880, "grp": "nl", "class": 1, "rating": "I", "cost": 24260, "mass": 2, "power": 0.4, "mount": "F", "type": "E", "armourpen": "C", "thermload": 2, "clip": 1, "ammo": 24, "ammocost": 209 },
     { "id": "2k", "edID": 128049501, "eddbID": 881, "grp": "nl", "class": 2, "rating": "I", "cost": 294080, "mass": 4, "power": 0.4, "mount": "F", "type": "E", "armourpen": "C", "thermload": 3, "clip": 3, "ammo": 24, "ammocost": 209 },
-    { "id": "kp", "edID: 128671448, "eddbID": 1523, "grp": "nl", "name":"Shock Mine Launcher", "class": 1, "rating": "I", "cost": 36400, "mass": 2, "power": 0.4, "mount": "F", "type": "E", "armourpen": "C", "thermload": 2, "clip": 1, "ammo": 24, "ammocost": 209 }
+    { "id": "kp", "edID": 128671448, "eddbID": 1523, "grp": "nl", "name":"Shock Mine Launcher", "class": 1, "rating": "I", "cost": 36400, "mass": 2, "power": 0.4, "mount": "F", "type": "E", "armourpen": "C", "thermload": 2, "clip": 1, "ammo": 24, "ammocost": 209 }
   ]
 }

--- a/modules/hardpoints/mine_launcher.json
+++ b/modules/hardpoints/mine_launcher.json
@@ -2,6 +2,6 @@
   "nl": [
     { "id": "2j", "edID": 128049500, "eddbID": 880, "grp": "nl", "class": 1, "rating": "I", "cost": 24260, "mass": 2, "power": 0.4, "mount": "F", "type": "E", "armourpen": "C", "thermload": 2, "clip": 1, "ammo": 24, "ammocost": 209 },
     { "id": "2k", "edID": 128049501, "eddbID": 881, "grp": "nl", "class": 2, "rating": "I", "cost": 294080, "mass": 4, "power": 0.4, "mount": "F", "type": "E", "armourpen": "C", "thermload": 3, "clip": 3, "ammo": 24, "ammocost": 209 },
-    { "id": "kp", "eddbID": 0, "grp": "nl", "name":"Shock Mine Launcher", "class": 1, "rating": "I", "cost": 36400, "mass": 2, "power": 0.4, "mount": "F", "type": "E", "armourpen": "C", "thermload": 2, "clip": 1, "ammo": 24, "ammocost": 209 }
+    { "id": "kp", "edID: 128671448, "eddbID": 0, "grp": "nl", "name":"Shock Mine Launcher", "class": 1, "rating": "I", "cost": 36400, "mass": 2, "power": 0.4, "mount": "F", "type": "E", "armourpen": "C", "thermload": 2, "clip": 1, "ammo": 24, "ammocost": 209 }
   ]
 }

--- a/modules/hardpoints/mine_launcher.json
+++ b/modules/hardpoints/mine_launcher.json
@@ -2,6 +2,6 @@
   "nl": [
     { "id": "2j", "edID": 128049500, "eddbID": 880, "grp": "nl", "class": 1, "rating": "I", "cost": 24260, "mass": 2, "power": 0.4, "mount": "F", "type": "E", "armourpen": "C", "thermload": 2, "clip": 1, "ammo": 24, "ammocost": 209 },
     { "id": "2k", "edID": 128049501, "eddbID": 881, "grp": "nl", "class": 2, "rating": "I", "cost": 294080, "mass": 4, "power": 0.4, "mount": "F", "type": "E", "armourpen": "C", "thermload": 3, "clip": 3, "ammo": 24, "ammocost": 209 },
-    { "id": "kp", "edID: 128671448, "eddbID": 0, "grp": "nl", "name":"Shock Mine Launcher", "class": 1, "rating": "I", "cost": 36400, "mass": 2, "power": 0.4, "mount": "F", "type": "E", "armourpen": "C", "thermload": 2, "clip": 1, "ammo": 24, "ammocost": 209 }
+    { "id": "kp", "edID: 128671448, "eddbID": 1523, "grp": "nl", "name":"Shock Mine Launcher", "class": 1, "rating": "I", "cost": 36400, "mass": 2, "power": 0.4, "mount": "F", "type": "E", "armourpen": "C", "thermload": 2, "clip": 1, "ammo": 24, "ammocost": 209 }
   ]
 }

--- a/modules/internal/bi_weave_shield_generator.json
+++ b/modules/internal/bi_weave_shield_generator.json
@@ -1,12 +1,12 @@
 {
   "bsg": [
-    { "id": "B6", "eddbID": 1530, "grp": "bsg", "class": 1, "rating": "C", "cost": 7710,     "mass": 1.3, "power": 1.2, "minmass": 13,  "optmass": 25,   "maxmass": 63,   "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 2.4 },
-    { "id": "B5", "eddbID": 1531, "grp": "bsg", "class": 2, "rating": "C", "cost": 26710,    "mass": 2.5, "power": 1.5, "minmass": 23,  "optmass": 55,   "maxmass": 138,  "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 2.4 },
-    { "id": "B4", "eddbID": 1532, "grp": "bsg", "class": 3, "rating": "C", "cost": 84650,    "mass": 5,   "power": 1.8, "minmass": 83,  "optmass": 165,  "maxmass": 413,  "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 2.4 },
-    { "id": "B3", "eddbID": 1533, "grp": "bsg", "class": 4, "rating": "C", "cost": 268350,   "mass": 10,  "power": 2.2, "minmass": 143, "optmass": 285,  "maxmass": 713,  "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 2.85 },
-    { "id": "B2", "eddbID": 1534, "grp": "bsg", "class": 5, "rating": "C", "cost": 850660,   "mass": 20,  "power": 2.6, "minmass": 203, "optmass": 405,  "maxmass": 1013, "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 3.75 },
-    { "id": "B1", "eddbID": 1535, "grp": "bsg", "class": 6, "rating": "C", "cost": 2696600,  "mass": 40,  "power": 3.1, "minmass": 270, "optmass": 540,  "maxmass": 1350, "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 4.8 },
-    { "id": "B0", "eddbID": 1536, "grp": "bsg", "class": 7, "rating": "C", "cost": 8548200,  "mass": 80,  "power": 3.5, "minmass": 530, "optmass": 1060, "maxmass": 2650, "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 6 },
-    { "id": "B7", "eddbID": 1537, "grp": "bsg", "class": 8, "rating": "C", "cost": 27097750, "mass": 160, "power": 4,   "minmass": 900, "optmass": 1800, "maxmass": 4500, "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 10.8 }
+    { "id": "B6", "edID": 128671331,"eddbID": 1530, "grp": "bsg", "class": 1, "rating": "C", "cost": 7710,     "mass": 1.3, "power": 1.2, "minmass": 13,  "optmass": 25,   "maxmass": 63,   "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 2.4 },
+    { "id": "B5", "edID": 128671332,"eddbID": 1531, "grp": "bsg", "class": 2, "rating": "C", "cost": 26710,    "mass": 2.5, "power": 1.5, "minmass": 23,  "optmass": 55,   "maxmass": 138,  "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 2.4 },
+    { "id": "B4", "edID": 128671333,"eddbID": 1532, "grp": "bsg", "class": 3, "rating": "C", "cost": 84650,    "mass": 5,   "power": 1.8, "minmass": 83,  "optmass": 165,  "maxmass": 413,  "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 2.4 },
+    { "id": "B3", "edID": 128671334,"eddbID": 1533, "grp": "bsg", "class": 4, "rating": "C", "cost": 268350,   "mass": 10,  "power": 2.2, "minmass": 143, "optmass": 285,  "maxmass": 713,  "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 2.85 },
+    { "id": "B2", "edID": 128671335,"eddbID": 1534, "grp": "bsg", "class": 5, "rating": "C", "cost": 850660,   "mass": 20,  "power": 2.6, "minmass": 203, "optmass": 405,  "maxmass": 1013, "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 3.75 },
+    { "id": "B1", "edID": 128671336,"eddbID": 1535, "grp": "bsg", "class": 6, "rating": "C", "cost": 2696600,  "mass": 40,  "power": 3.1, "minmass": 270, "optmass": 540,  "maxmass": 1350, "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 4.8 },
+    { "id": "B0", "edID": 128671337,"eddbID": 1536, "grp": "bsg", "class": 7, "rating": "C", "cost": 8548200,  "mass": 80,  "power": 3.5, "minmass": 530, "optmass": 1060, "maxmass": 2650, "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 6 },
+    { "id": "B7", "edID": 128671338,"eddbID": 1537, "grp": "bsg", "class": 8, "rating": "C", "cost": 27097750, "mass": 160, "power": 4,   "minmass": 900, "optmass": 1800, "maxmass": 4500, "minmul": 1.4, "optmul": 0.9, "maxmul": 0.4, "recover": 10.8 }
   ]
 }

--- a/modules/internal/planetary_vehicle_hanger.json
+++ b/modules/internal/planetary_vehicle_hanger.json
@@ -1,12 +1,12 @@
 {
   "pv": [
-    { "id": "v1", "eddbID": 1524, "grp": "pv", "class": 6, "rating": "H", "cost": 576000, "power": 0.6, "mass": 34, "bays": 4 },
-    { "id": "v2", "eddbID": 1525, "grp": "pv", "class": 6, "rating": "G", "cost": 691200, "power": 1.8, "mass": 17, "bays": 4 },
+    { "id": "v1", "edID": 128672292, "eddbID": 1524, "grp": "pv", "class": 6, "rating": "H", "cost": 576000, "power": 0.6, "mass": 34, "bays": 4 },
+    { "id": "v2", "edID": 128672293, "eddbID": 1525, "grp": "pv", "class": 6, "rating": "G", "cost": 691200, "power": 1.8, "mass": 17, "bays": 4 },
 
-    { "id": "v3", "eddbID": 1526, "grp": "pv", "class": 4, "rating": "H", "cost": 72000, "power": 0.4, "mass": 20, "bays": 2 },
-    { "id": "v4", "eddbID": 1527, "grp": "pv", "class": 4, "rating": "G", "cost": 86400, "power": 1.2, "mass": 10, "bays": 2 },
+    { "id": "v3", "edID": 128672290, "eddbID": 1526, "grp": "pv", "class": 4, "rating": "H", "cost": 72000, "power": 0.4, "mass": 20, "bays": 2 },
+    { "id": "v4", "edID": 128672291, "eddbID": 1527, "grp": "pv", "class": 4, "rating": "G", "cost": 86400, "power": 1.2, "mass": 10, "bays": 2 },
 
-    { "id": "v5", "eddbID": 1528, "grp": "pv", "class": 2, "rating": "H", "cost": 18000, "power": 0.25, "mass": 12, "bays": 1 },
-    { "id": "v6", "eddbID": 1529, "grp": "pv", "class": 2, "rating": "G", "cost": 21600, "power": 0.75, "mass": 6, "bays": 1 }
+    { "id": "v5", "edID": 128672288, "eddbID": 1528, "grp": "pv", "class": 2, "rating": "H", "cost": 18000, "power": 0.25, "mass": 12, "bays": 1 },
+    { "id": "v6", "edID": 128672289, "eddbID": 1529, "grp": "pv", "class": 2, "rating": "G", "cost": 21600, "power": 0.75, "mass": 6, "bays": 1 }
   ]
 }

--- a/modules/internal/pristmatic_shield_generator.json
+++ b/modules/internal/pristmatic_shield_generator.json
@@ -1,12 +1,12 @@
 {
   "psg": [
-    { "id": "p6", "eddbID": 1485, "grp": "psg", "class": 1, "rating": "A", "cost": 132200,    "mass": 2.5, "power": 2.52, "minmass": 13,  "optmass": 25,   "maxmass": 63,   "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 1.2 },
-    { "id": "p5", "eddbID": 1486, "grp": "psg", "class": 2, "rating": "A", "cost": 240340,    "mass": 5,   "power": 3.15, "minmass": 23,  "optmass": 55,   "maxmass": 138,  "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 1.2 },
-    { "id": "p4", "eddbID": 1487, "grp": "psg", "class": 3, "rating": "A", "cost": 761870,    "mass": 10,  "power": 3.78, "minmass": 83,  "optmass": 165,  "maxmass": 413,  "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 1.2 },
-    { "id": "p3", "eddbID": 1488, "grp": "psg", "class": 4, "rating": "A", "cost": 2415120,   "mass": 20,  "power": 4.62, "minmass": 143, "optmass": 285,  "maxmass": 713,  "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 1.425 },
-    { "id": "p2", "eddbID": 1489, "grp": "psg", "class": 5, "rating": "A", "cost": 7655930,   "mass": 40,  "power": 5.46, "minmass": 203, "optmass": 405,  "maxmass": 1013, "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 1.875 },
-    { "id": "p1", "eddbID": 1490, "grp": "psg", "class": 6, "rating": "A", "cost": 24269300,  "mass": 80,  "power": 6.51, "minmass": 270, "optmass": 540,  "maxmass": 1350, "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 2.4 },
-    { "id": "p0", "eddbID": 1491, "grp": "psg", "class": 7, "rating": "A", "cost": 76933670,  "mass": 160, "power": 7.35, "minmass": 530, "optmass": 1060, "maxmass": 2650, "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 3 },
-    { "id": "p7", "eddbID": 1492, "grp": "psg", "class": 8, "rating": "A", "cost": 243879730, "mass": 320, "power": 8.4,  "minmass": 900, "optmass": 1800, "maxmass": 4500, "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 3.6 }
+    { "id": "p6", "edID": 128671323, "eddbID": 1485, "grp": "psg", "class": 1, "rating": "A", "cost": 132200,    "mass": 2.5, "power": 2.52, "minmass": 13,  "optmass": 25,   "maxmass": 63,   "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 1.2 },
+    { "id": "p5", "edID": 128671324, "eddbID": 1486, "grp": "psg", "class": 2, "rating": "A", "cost": 240340,    "mass": 5,   "power": 3.15, "minmass": 23,  "optmass": 55,   "maxmass": 138,  "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 1.2 },
+    { "id": "p4", "edID": 128671325, "eddbID": 1487, "grp": "psg", "class": 3, "rating": "A", "cost": 761870,    "mass": 10,  "power": 3.78, "minmass": 83,  "optmass": 165,  "maxmass": 413,  "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 1.2 },
+    { "id": "p3", "edID": 128671326, "eddbID": 1488, "grp": "psg", "class": 4, "rating": "A", "cost": 2415120,   "mass": 20,  "power": 4.62, "minmass": 143, "optmass": 285,  "maxmass": 713,  "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 1.425 },
+    { "id": "p2", "edID": 128671327, "eddbID": 1489, "grp": "psg", "class": 5, "rating": "A", "cost": 7655930,   "mass": 40,  "power": 5.46, "minmass": 203, "optmass": 405,  "maxmass": 1013, "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 1.875 },
+    { "id": "p1", "edID": 128671328, "eddbID": 1490, "grp": "psg", "class": 6, "rating": "A", "cost": 24269300,  "mass": 80,  "power": 6.51, "minmass": 270, "optmass": 540,  "maxmass": 1350, "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 2.4 },
+    { "id": "p0", "edID": 128671329, "eddbID": 1491, "grp": "psg", "class": 7, "rating": "A", "cost": 76933670,  "mass": 160, "power": 7.35, "minmass": 530, "optmass": 1060, "maxmass": 2650, "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 3 },
+    { "id": "p7", "edID": 202115326, "eddbID": 1492, "grp": "psg", "class": 8, "rating": "A", "cost": 243879730, "mass": 320, "power": 8.4,  "minmass": 900, "optmass": 1800, "maxmass": 4500, "minmul": 2, "optmul": 1.5, "maxmul": 1, "recover": 3.6 }
   ]
 }


### PR DESCRIPTION
There are a few missing Elite and EDDB iDs in master, I've added those where I have the data.

At this stage the only missing Elite IDs are those from the remaining PowerPlay modules.  I'm  hoping to catch those in EDDI over the next few weeks as people start to use it more, and will pass them along as I find them
