### PR TITLE
Updates for 2.1

### DIFF
--- a/modules/hardpoints/beam_laser.json
+++ b/modules/hardpoints/beam_laser.json
@@ -1,5 +1,8 @@
 {
   "bl": [
+    { "id": "0w", "edID": 128049431, "eddbID": 0, "grp": "bl", "class": 4, "rating": "C", "cost": 2396160, "mass": 16, "power": 2.9, "mount": "F", "type": "T", "damage": 7, "armourpen": "A", "rof": null, "dps": 41.4, "mjeps": 9.10, "thermload": 9.9 },
+    { "id": "0x", "edID": 128681994, "eddbID": 0, "grp": "bl", "class": 4, "rating": "A", "cost": 8746160, "mass": 16, "power": 2.86, "mount": "G", "type": "T", "damage": 7, "armourpen": "A", "rof": null, "dps": 32.7, "mjeps" : 8.99, "thermload": 10.6 },
+
     { "id": "0u", "edID": 128049430, "eddbID": 843, "grp": "bl", "class": 3, "rating": "C", "cost": 1177600, "mass": 8, "power": 1.8, "mount": "F", "type": "T", "damage": 6, "armourpen": "A", "rof": null, "dps": 5, "mjdps" : 30.33, "mjeps" : 5.65, "thermload": 5 },
     { "id": "0v", "edID": 128049434, "eddbID": 846, "grp": "bl", "class": 3, "rating": "C", "cost": 2396160, "mass": 8, "power": 1.78, "mount": "G", "type": "T", "damage": 6, "armourpen": "A", "rof": null, "dps": 4, "mjdps" : 24.00, "mjeps" : 5.59, "thermload": 6 },
     { "id": "0o", "edID": 128049437, "eddbID": 849, "grp": "bl", "class": 3, "rating": "D", "cost": 19399600, "mass": 8, "power": 1.68, "mount": "T", "type": "T", "damage": 5, "armourpen": "A", "rof": null, "dps": 4, "mjdps" : 14.44, "mjeps" : 3.54, "thermload": 4 },

--- a/modules/hardpoints/multi_cannon.json
+++ b/modules/hardpoints/multi_cannon.json
@@ -1,5 +1,11 @@
 {
   "mc": [
+    { "id": "7n", "edID": 128049458, "eddbID": 0, "grp": "mc", "class": 4, "rating": "A", "cost": 1177600, "mass": 16, "power": 0.73, "mount": "F", "type": "K", "damage": 4, "armourpen": "A", "rof": 3.0, "dps": 24.5, "mjeps": 0.72, "thermload": 0.4, "clip": 90, "ssdam" : 4.0, "ammo": 2100, "ammocost": 1 },
+    { "id": "7o", "edID": 128681996, "eddbID": 0, "grp": "mc", "class": 4, "rating": "A", "cost": 6377600, "mass": 16, "power": 1.22, "mount": "G", "type": "K", "damage": 4, "armourpen": "A", "rof": 3.4, "dps": 23.3, "mjeps": 1.258, "thermload": 0.5, "clip": 90, "ssdam" : 3.5 , "ammo": 2100, "ammocost": 1 },
+
+    { "id": "7k", "edID": 128049457, "eddbID": 0, "grp": "mc", "class": 3, "rating": "C", "cost": 140400, "mass": 8, "power": 0.64, "mount": "F", "type": "K", "damage": 3, "armourpen": "A", "rof": 5.9, "dps": 20.8, "mjeps": 1.062, "thermload": 0.3, "clip": 90, "ssdam" : 3.5, "ammo": 2100, "ammocost": 1 },
+    { "id": "7l", "edID": 128049461, "eddbID": 0, "grp": "mc", "class": 3, "rating": "C", "cost": 578436, "mass": 8, "power": 0.97, "mount": "G", "type": "K", "damage": 3, "armourpen": "A", "rof": 6.7, "dps": 18.9, "mjeps": 1.675, "thermload": 0.3, "clip": 90, "ssdam" : 2.8, "ammo": 2100, "ammocost": 1 },
+
     { "id": "26", "edID": 128049456, "eddbID": 868, "grp": "mc", "class": 2, "rating": "E", "cost": 38000, "mass": 4, "power": 0.46, "mount": "F", "type": "K", "damage": 2, "armourpen": "A", "rof": 7, "dps": 4, "thermload": 1, "clip": 90, "mjdps" : 6.02, "ssdam" : 1.20, "ammo": 2100, "ammocost": 1 },
     { "id": "27", "edID": 128049460, "eddbID": 870, "grp": "mc", "class": 2, "rating": "F", "cost": 57000, "mass": 4, "power": 0.64, "mount": "G", "type": "K", "damage": 2, "armourpen": "A", "rof": 7.5, "dps": 4, "thermload": 1, "clip": 90, "mjdps" : 5.59, "ssdam" : 1.03, "ammo": 2100, "ammocost": 1 },
     { "id": "28", "edID": 128049463, "eddbID": 872, "grp": "mc", "class": 2, "rating": "F", "cost": 1292800, "mass": 4, "power": 0.5, "mount": "T", "type": "K", "damage": 2, "armourpen": "A", "rof": 5.3, "dps": 3, "thermload": 1, "clip": 90, "mjdps" : 2.15, "ssdam" : 0.52, "ammo": 2100, "ammocost": 1 },

--- a/modules/hardpoints/pulse_laser.json
+++ b/modules/hardpoints/pulse_laser.json
@@ -1,5 +1,8 @@
 {
   "pl": [
+    { "id": "7q", "edID": 128049385, "eddbID": 0, "grp": "pl", "class": 4, "rating": "A", "cost": 177600, "mass": 16, "power": 1.33, "mount": "F", "type": "T", "damage": 5, "armourpen": "A", "rof": 2.6, "dps": 26.9, "mjeps": 4.264, "ssdam": 10.2 , "thermload": 1.6 },
+    { "id": "7r", "edID": 128681995, "eddbID": 0, "grp": "pl", "class": 4, "rating": "A", "cost": 877600, "mass": 16, "power": 1.37, "mount": "G", "type": "T", "damage": 5, "armourpen": "A", "rof": 2.8, "dps": 21.7, "mjeps": 4.368, "ssdam" : 7.8, "thermload": 1.6 },
+
     { "id": "1d", "edID": 128049383, "eddbID": 825, "grp": "pl", "class": 3, "rating": "D", "cost": 70400, "mass": 8, "power": 0.9, "mount": "F", "type": "T", "damage": 4, "armourpen": "A", "rof": 3, "dps": 4, "mjdps" : 21.62, "mjeps" : 2.86, "ssdam" : 7.07, "thermload": 1 },
     { "id": "1e", "edID": 128049387, "eddbID": 828, "grp": "pl", "class": 3, "rating": "E", "cost": 140600, "mass": 8, "power": 0.92, "mount": "G", "type": "T", "damage": 3, "armourpen": "A", "rof": 3.2, "dps": 4, "mjdps" : 18.28, "mjeps" : 2.98, "ssdam" : 5.59, "thermload": 1 },
     { "id": "1f", "edID": 128049390, "eddbID": 831, "grp": "pl", "class": 3, "rating": "F", "cost": 400400, "mass": 8, "power": 0.89, "mount": "T", "type": "T", "damage": 3, "armourpen": "A", "rof": 2.3, "dps": 3, "mjdps" : 7.05, "mjeps" : 1.24, "ssdam" : 3.15, "thermload": 1 },

--- a/modules/standard/thrusters.json
+++ b/modules/standard/thrusters.json
@@ -7,10 +7,10 @@
     { "id":"tu", "edID": 128064102, "eddbID": 960, "grp": "t", "class": 8, "rating": "A", "M": 0.04, "P": 2.33, "cost": 162586490, "mass": 160, "power": 10.8, "optmass": 3360, "maxmass": 5040 },
 
     { "id":"tt", "edID": 128064093, "eddbID": 951, "grp": "t", "class": 7, "rating": "E", "M": 0.17, "P": 0.235, "cost": 633200, "mass": 80, "power": 6.08, "optmass": 1440, "maxmass": 2160 },
-    { "id":"ts", "edID": 128064094, "eddbID": 952, "grp": "t", "class": 7, "rating": "D", "M": 0.14, "P": 0.5145, "cost": 1899600, "mass": 32, "power": 6.84, "optmass": 1620, "maxmass": 2430 },
+    { "id":"ts", "edID": 128064094, "eddbID": 952, "grp": "t", "class": 7, "rating": "D", "M": 0.14, "P": 0.5145, "cost": 1899600, "mass": 32, "power": 6.84, "optmass": 1620, "maxmass": 2430, "minmult": 0.86, "optmult": 1, "maxmult": 1.06 },
     { "id":"tr", "edID": 128064095, "eddbID": 953, "grp": "t", "class": 7, "rating": "C", "M": 0.10, "P": 1, "cost": 5698790, "mass": 80, "power": 7.6, "optmass": 1800, "maxmass": 2700 },
-    { "id":"tq", "edID": 128064096, "eddbID": 954, "grp": "t", "class": 7, "rating": "B", "M": 0.07, "P": 1.51, "cost": 17096370, "mass": 128, "power": 8.36, "optmass": 1980, "maxmass": 2970 },
-    { "id":"tp", "edID": 128064097, "eddbID": 955, "grp": "t", "class": 7, "rating": "A", "M": 0.04, "P": 2.33, "cost": 51289110, "mass": 80, "power": 9.12, "optmass": 2160, "maxmass": 3240 },
+    { "id":"tq", "edID": 128064096, "eddbID": 954, "grp": "t", "class": 7, "rating": "B", "M": 0.07, "P": 1.51, "cost": 17096370, "mass": 128, "power": 8.36, "optmass": 1980, "maxmass": 2970, "minmult": 0.93, "optmult": 1, "maxmult": 1.13 },
+    { "id":"tp", "edID": 128064097, "eddbID": 955, "grp": "t", "class": 7, "rating": "A", "M": 0.04, "P": 2.33, "cost": 51289110, "mass": 80, "power": 9.12, "optmass": 2160, "maxmass": 3240, "minmult": 0.96, "optmult": 1, "maxmult": 1.16 },
 
     { "id":"to", "edID": 128064088, "eddbID": 946, "grp": "t", "class": 6, "rating": "E", "M": 0.17, "P": 0.235, "cost": 199750, "mass": 40, "power": 5.04, "optmass": 960, "maxmass": 1440 },
     { "id":"tn", "edID": 128064089, "eddbID": 947, "grp": "t", "class": 6, "rating": "D", "M": 0.14, "P": 0.5145, "cost": 599240, "mass": 16, "power": 5.67, "optmass": 1080, "maxmass": 1620 },
@@ -38,8 +38,11 @@
 
     { "id":"t4", "edID": 128064068, "eddbID": 926, "grp": "t", "class": 2, "rating": "E", "M": 0.17, "P": 0.235, "cost": 1980, "mass": 2.5, "power": 2, "optmass": 48, "maxmass": 72 },
     { "id":"t3", "edID": 128064069, "eddbID": 927, "grp": "t", "class": 2, "rating": "D", "M": 0.14, "P": 0.5145, "cost": 5930, "mass": 1, "power": 2.25, "optmass": 54, "maxmass": 81 },
-    { "id":"t2", "edID": 128064070, "eddbID": 928, "grp": "t", "class": 2, "rating": "C", "M": 0.10, "P": 1, "cost": 17800, "mass": 2.5, "power": 2.5, "optmass": 60, "maxmass": 90 },
+    { "id":"t2", "edID": 128064070, "eddbID": 928, "grp": "t", "class": 2, "rating": "C", "M": 0.10, "P": 1, "cost": 17800, "mass": 2.5, "power": 2.5, "optmass": 60, "maxmass": 90, "minmult": 0.9, "optmult": 1, "maxmult": 1.1 },
     { "id":"t1", "edID": 128064071, "eddbID": 929, "grp": "t", "class": 2, "rating": "B", "M": 0.07, "P": 1.51, "cost": 53410, "mass": 4, "power": 2.75, "optmass": 66, "maxmass": 99 },
-    { "id":"t0", "edID": 128064072, "eddbID": 930, "grp": "t", "class": 2, "rating": "A", "M": 0.04, "P": 2.33, "cost": 160220, "mass": 2.5, "power": 3, "optmass": 72, "maxmass": 108 }
+    { "id":"t0", "edID": 128064072, "eddbID": 930, "grp": "t", "class": 2, "rating": "A", "M": 0.04, "P": 2.33, "cost": 160220, "mass": 2.5, "power": 3, "optmass": 72, "maxmass": 108, "minmult": 0.96, "optmult": 1, "maxmult": 1.16 },
+
+    { "id":"tz", "edID": 128682013, "eddbID": 0, "grp": "t", "class": 3, "rating": "A", "name": "Enhanced Performance Thrusters", "M": 0.04, "P": 2.33, "cost": 5103952, "mass": 5, "power": 3, "optmass": 90, "maxmass": 200, "minmult": 0.90, "optmult": 1.15, "maxmult": 1.37 },
+    { "id":"u0", "edID": 128682014, "eddbID": 0, "grp": "t", "class": 2, "rating": "A", "name": "Enhanced Performance Thrusters", "M": 0.04, "P": 2.33, "cost": 1610080, "mass": 2.5, "power": 3, "optmass": 60, "maxmass": 120, "minmult": 0.90, "optmult": 1.15, "maxmult": 1.37 }
   ]
 }


### PR DESCRIPTION
I've added in the new modules for 2.1.  A few gotchas:
- the numbers for distributor draw are present for hardpoints, so I've calculated EPS as distributor draw per shot \* rate of fire
- I wasn't sure how to calculate mjdps so left it out of the weapons
- I wasn't sure how to calculate the thruster curve values M and P so left them out.  I have, however, added in FD's multiplier information for both the new thrusters as well as some of the existing ones; hopefully you can work out M and P for these given the values available
